### PR TITLE
Fix log escaping in class results

### DIFF
--- a/src/main/resources/org/uncommons/reportng/templates/html/class-results.ftl
+++ b/src/main/resources/org/uncommons/reportng/templates/html/class-results.ftl
@@ -55,7 +55,7 @@
             <#if (output?size > 0)>
                 <div class="testOutput">
                     <#list output as line>
-                        <#if meta.shouldEscapeOutput??>
+                        <#if meta.shouldEscapeOutput()>
                             ${utils.escapeHTMLString(line)}<br/>
                         <#else>
                             ${line}


### PR DESCRIPTION
Log output in Class Results are currently always escaped as the MetaData flag is evaluated incorrectly.